### PR TITLE
Retrieve patron statistical codes from patron ID

### DIFF
--- a/lib/voyager_helpers/liberator.rb
+++ b/lib/voyager_helpers/liberator.rb
@@ -346,6 +346,16 @@ module VoyagerHelpers
         end
       end
 
+      # @param patron_id [String] Either a netID, PUID, or PU Barcode
+      # @return [Array<Hash>] Patron Statistical Categories with one key: :stat_code.
+      def get_patron_stat_codes(patron_id)
+        id_type = determine_id_type(patron_id)
+        query = VoyagerHelpers::Queries.patron_stat_codes(patron_id, id_type)
+        connection do |c|
+          exec_get_patron_stat_codes(query, c)
+        end
+      end
+
       # @param bib_id [Fixnum] Find order status for provided bib ID
       # @return [String] on-order status message and date of status if the status code in whitelist
       # if code is not whitelisted return nil
@@ -529,6 +539,14 @@ module VoyagerHelpers
           info[:patron_id] = a.shift
         end
         info
+      end
+
+      def exec_get_patron_stat_codes(query, conn)
+        stat_codes = []
+        conn.exec(query) do |stat_code|
+          stat_codes << { stat_code: stat_code }
+        end
+        stat_codes
       end
 
       def accumulate_items_for_holding(mfhd_id, conn)

--- a/lib/voyager_helpers/queries.rb
+++ b/lib/voyager_helpers/queries.rb
@@ -290,6 +290,23 @@ module VoyagerHelpers
           )
       end
 
+      def patron_stat_codes(id, id_field)
+        %Q(
+          SELECT
+            patron_stat_code.patron_stat_desc
+          FROM patron_stat_code
+            JOIN patron_stats
+              ON patron_stat_code.patron_stat_id = patron_stats.patron_stat_id
+            JOIN patron
+              ON patron_stats.patron_id = patron.patron_id
+            JOIN patron_barcode
+              ON patron.patron_id = patron_barcode.patron_id
+          WHERE
+            #{id_field}='#{id}'
+            AND patron_barcode.barcode_status = 1
+        )
+      end
+
       def active_courses
         %Q(
           SELECT


### PR DESCRIPTION
Retrieves a patron's statistical categories for the purpose of allowing the request service to limit certain pickup locations to specific user categories (currently, library staff).