### PR TITLE
Remove deprecated ReCAP methods; add new ReCAP query

### DIFF
--- a/lib/voyager_helpers/liberator.rb
+++ b/lib/voyager_helpers/liberator.rb
@@ -29,38 +29,6 @@ module VoyagerHelpers
         end
       end
 
-      def get_bib_with_recap_holdings(bib_id, conn=nil)
-        connection(conn) do |c|
-          bib = get_bib_without_holdings(bib_id, c)
-          unless bib.nil?
-            holdings = get_recap_holding_records(bib_id, c)
-            [bib,holdings].flatten!
-          end
-        end
-      end
-
-      def get_recap_bibids(conn=nil, file_name)
-        query = VoyagerHelpers::Queries.all_recap_bib_ids
-        File.open(file_name, 'a') do |output|
-          connection(conn) do |c|
-            c.exec(query) do |r|
-              output.puts(r.join(''))
-            end
-          end
-        end
-      end
-
-      def get_recap_holding_records(bib_id, conn=nil)
-        records = []
-        connection(conn) do |c|
-          get_recap_bib_mfhd_ids(bib_id, c).each do |mfhd_id|
-            record = get_holding_record(mfhd_id, c)
-            records << record unless record.nil?
-          end
-        end
-        records
-      end
-
       def get_bib_update_date(bib_id, conn=nil)
         query = VoyagerHelpers::Queries.bib_update_date(bib_id)
         connection(conn) do |c|
@@ -637,12 +605,6 @@ module VoyagerHelpers
           c.exec(query) { |s| segments << s }
         end
         segments
-      end
-
-      def get_recap_bib_mfhd_ids(bib_id, conn=nil)
-        connection(conn) do |c|
-          exec_get_bib_mfhd_ids(VoyagerHelpers::Queries.recap_mfhd_ids(bib_id), c)
-        end
       end
 
       def get_bib_mfhd_ids(bib_id, conn=nil)

--- a/lib/voyager_helpers/queries.rb
+++ b/lib/voyager_helpers/queries.rb
@@ -37,7 +37,7 @@ module VoyagerHelpers
           503
           504
           515
-        ).join(', ')
+        )
       end
       
       def bib_suppressed(bib_id)
@@ -248,32 +248,6 @@ module VoyagerHelpers
             mfhd_master.suppress_in_opac = 'N' AND
             item_barcode.barcode_status = '1' AND
             item_barcode.item_barcode = #{item_barcode}
-        )
-      end
-
-      def all_recap_bib_ids
-        %Q(
-          SELECT bib_master.bib_id
-          FROM (
-                 (
-                   (bib_master JOIN bib_mfhd ON bib_master.bib_id = bib_mfhd.bib_id) 
-                 JOIN mfhd_master ON bib_mfhd.mfhd_id = mfhd_master.mfhd_id) 
-               JOIN mfhd_item ON mfhd_master.mfhd_id = mfhd_item.mfhd_id) 
-          WHERE mfhd_master.location_id IN (#{recap_locations})
-          AND bib_master.suppress_in_opac = 'N'
-          AND mfhd_master.suppress_in_opac = 'N'
-          GROUP BY bib_master.bib_id
-          ORDER BY bib_master.bib_id
-        )
-      end
-
-      def recap_mfhd_ids(bib_id)
-        %Q(
-        SELECT bib_mfhd.mfhd_id
-        FROM bib_mfhd JOIN mfhd_master ON bib_mfhd.mfhd_id = mfhd_master.mfhd_id
-        WHERE (bib_id = #{bib_id}
-        and location_id IN (#{recap_locations})
-        and suppress_in_opac = 'N')
         )
       end
 

--- a/lib/voyager_helpers/queries.rb
+++ b/lib/voyager_helpers/queries.rb
@@ -39,7 +39,33 @@ module VoyagerHelpers
           515
         )
       end
-      
+
+      def barcode_record_ids_location(barcodes, locations)
+        barcodes = OCI8::in_cond(:barcodes, barcodes)
+        locations = OCI8::in_cond(:locations, locations)
+        %Q(
+          SELECT
+            bib_item.bib_id,
+            mfhd_item.mfhd_id,
+            item_barcode.item_id
+          FROM item_barcode
+            JOIN mfhd_item
+              ON item_barcode.item_id = mfhd_item.item_id
+            JOIN bib_item
+              ON item_barcode.item_id = bib_item.item_id
+            JOIN mfhd_master
+              ON mfhd_item.mfhd_id = mfhd_master.mfhd_id
+            JOIN bib_master
+              ON bib_item.bib_id = bib_master.bib_id
+          WHERE
+            item_barcode.item_barcode IN (#{barcodes.names})
+            AND bib_master.suppress_in_opac = 'N'
+            AND mfhd_master.suppress_in_opac = 'N'
+            AND mfhd_master.location_id IN (#{locations.names})
+            AND item_barcode.barcode_status = 1
+        )
+      end
+
       def bib_suppressed(bib_id)
         %Q(
         SELECT suppress_in_opac FROM bib_master


### PR DESCRIPTION
The old ReCAP methods are obsolete, as the data is generated from an external file of barcodes as opposed to barcodes within Voyager. The new query allows one to look up an array of barcodes from an external source to find IDs (bib, MFHD, and item) associated with those barcodes in particular locations.