### PR TITLE
Fix full_item_info query to only return the active barcode

### DIFF
--- a/lib/voyager_helpers/queries.rb
+++ b/lib/voyager_helpers/queries.rb
@@ -84,7 +84,8 @@ module VoyagerHelpers
           LEFT JOIN item_barcode
             ON item_barcode.item_id = item.item_id
         WHERE item.item_id=#{item_id} AND
-          item_status.item_status NOT IN ('5', '6', '16', '19', '20', '21', '23', '24')
+          item_status.item_status NOT IN ('5', '6', '16', '19', '20', '21', '23', '24') AND
+          item_barcode.barcode_status = 1
         )
       end
 
@@ -246,7 +247,7 @@ module VoyagerHelpers
           WHERE
             bib_master.suppress_in_opac = 'N' AND
             mfhd_master.suppress_in_opac = 'N' AND
-            item_barcode.barcode_status = '1' AND
+            item_barcode.barcode_status = 1 AND
             item_barcode.item_barcode = #{item_barcode}
         )
       end


### PR DESCRIPTION
In the case that an inactive barcode is listed first in the item_barcode table, current behavior is to return the inactive barcode. This change will ensure that only the active barcode will be retrieved.