### PR TITLE
Creates new lookup for bib/mfhd/item combination based on barcode

### DIFF
--- a/lib/voyager_helpers/liberator.rb
+++ b/lib/voyager_helpers/liberator.rb
@@ -626,7 +626,7 @@ module VoyagerHelpers
             record_hash['fields'] << h
           end
         end #ReCAP-specific section ends here
-        record_hash['fields'] << {"876"=>{"ind1"=>"0", "ind2"=>"0", "subfields"=>[{"0"=>holding_id}, {"a"=>item[:id]}, {"h"=>recap_use_restriction}, {"j"=>item[:status]}, {"p"=>item[:barcode]}, {"t"=>item[:copy_number]}, {"x"=>group_designation}, {"z"=>customer_code}]}}
+        record_hash['fields'] << {"876"=>{"ind1"=>"0", "ind2"=>"0", "subfields"=>[{"0"=>holding_id.to_s}, {"a"=>item[:id].to_s}, {"h"=>recap_use_restriction}, {"j"=>item[:status]}, {"p"=>item[:barcode].to_s}, {"t"=>item[:copy_number].to_s}, {"x"=>group_designation}, {"z"=>customer_code}]}}
         MARC::Record.new_from_hash(record_hash)
       end
 

--- a/lib/voyager_helpers/queries.rb
+++ b/lib/voyager_helpers/queries.rb
@@ -40,9 +40,8 @@ module VoyagerHelpers
         )
       end
 
-      def barcode_record_ids_location(barcodes, locations)
+      def barcode_record_ids(barcodes)
         barcodes = OCI8::in_cond(:barcodes, barcodes)
-        locations = OCI8::in_cond(:locations, locations)
         %Q(
           SELECT
             bib_item.bib_id,
@@ -61,7 +60,6 @@ module VoyagerHelpers
             item_barcode.item_barcode IN (#{barcodes.names})
             AND bib_master.suppress_in_opac = 'N'
             AND mfhd_master.suppress_in_opac = 'N'
-            AND mfhd_master.location_id IN (#{locations.names})
             AND item_barcode.barcode_status = 1
         )
       end


### PR DESCRIPTION
Closes #10. 

This allows you to look up a bibliographic record with holdings and item info merged by an item barcode. If multiple bibliographic records are linked to the barcode, it returns an array of bibliographic records. The method 'merge_holding_item_into_bib' also includes some code specific to ReCAP middleware accession.
