### PR TITLE
time zone offset 0 for created/updated bib dumps

### DIFF
--- a/lib/voyager_helpers/sync_fu.rb
+++ b/lib/voyager_helpers/sync_fu.rb
@@ -60,7 +60,7 @@ module VoyagerHelpers
       def exec_ids_to_file(query, file_handle, connection)
         File.open(file_handle, 'w') do |f|
           connection.exec(query) do |id, created, updated|
-            f.write("#{id} #{created.to_datetime unless created.nil?} #{updated.to_datetime unless updated.nil?}\n")
+            f.write("#{id} #{created.to_datetime.new_offset(0) unless created.nil?} #{updated.to_datetime.new_offset(0) unless updated.nil?}\n")
           end
         end
       end


### PR DESCRIPTION
Prevent daylight savings time from affecting our daily diffs. See pulibrary/marc_liberation#45.