### PR TITLE
Encloses due date query in a connection block

### DIFF
--- a/lib/voyager_helpers/liberator.rb
+++ b/lib/voyager_helpers/liberator.rb
@@ -531,13 +531,13 @@ module VoyagerHelpers
       end
 
       def get_due_date_for_item(item_id, conn)
-        cursor = conn.parse(VoyagerHelpers::Queries.item_due_date)
-        cursor.bind_param(':item_id', item_id)
-        cursor.exec()
-        row = cursor.fetch
-        cursor.close()
-        if row
-          due_date = row.shift
+        connection(conn) do |c|
+          cursor = c.parse(VoyagerHelpers::Queries.item_due_date)
+          cursor.bind_param(':item_id', item_id)
+          cursor.exec()
+          row = cursor.fetch
+          cursor.close()
+          due_date = row.shift if row
         end
       end
 


### PR DESCRIPTION
Makes get_due_date_for_item more in line with other methods that have an inherited connection.