### PR TITLE
WIP Find updated ReCAP records and export to a file

### DIFF
--- a/lib/voyager_helpers/liberator.rb
+++ b/lib/voyager_helpers/liberator.rb
@@ -319,6 +319,19 @@ module VoyagerHelpers
         writer.close()
       end
 
+      def dump_merged_records_to_file(barcodes, file_name)
+        writer = MARC::XMLWriter.new(file_name)
+        connection do |c|
+          barcodes.each do |barcode|
+            records = VoyagerHelpers::Liberator.get_records_from_barcode(barcode)
+            records.each do |record|
+              writer.write(record) unless record.nil?
+            end
+          end
+        end
+        writer.close()
+      end
+
       # @param patron_id [String] Either a netID, PUID, or PU Barcode
       # @return [<Hash>]
       def get_patron_info(patron_id)
@@ -374,6 +387,23 @@ module VoyagerHelpers
         end
         records
       end
+
+    # @param date [String] in format yyyy-mm-dd hh24:mi:ss
+    # @return [Array]
+    def updated_recap_barcodes(date)
+      barcodes = []
+      query = VoyagerHelpers::Queries.recap_update_barcodes(date)
+      connection do |c|
+        cursor = c.parse(query)
+        cursor.bind_param(':last_diff_date', date)
+        cursor.exec()
+        while row = cursor.fetch
+          barcodes << row.first
+        end
+        cursor.close()
+      end
+      barcodes
+    end
 
       private
 


### PR DESCRIPTION
I utilized a SQL query to find updated ReCAP records. I based the file dump on the bib file dump that was already there. @kevinreiss @tampakis Does this seem like a reasonable way to go? I could generalize the method to find barcodes in certain locations, but that type of action doesn't make a lot of sense outside of the ReCAP context. The next step would be creating a dump job in marc_liberation.