### PR TITLE
enum and chron as separate properties

### DIFF
--- a/lib/voyager_helpers/liberator.rb
+++ b/lib/voyager_helpers/liberator.rb
@@ -249,9 +249,13 @@ module VoyagerHelpers
           due_date = format_due_date(item[:due_date], item[:on_reserve])
           item_hash[:due_date] = due_date unless due_date.nil?
           unless item[:enum].nil?
+            item_hash[:enum] = item[:enum]
             enum = item[:enum]
-            enum << " (#{item[:chron]})" unless item[:chron].nil?
-            item_hash[:enum] = enum
+            unless item[:chron].nil?
+              enum = enum + " (#{item[:chron]})"
+              item_hash[:chron] = item[:chron]
+            end
+            item_hash[:enum_display] = enum
           end
           item_availability << item_hash
         end
@@ -546,7 +550,7 @@ module VoyagerHelpers
         return if due_date.nil?
         unless due_date.to_datetime < DateTime.now-30
           if on_reserve == 'Y'
-            due_date = due_date.strftime('%-m/%-d/%Y %l:%M%P')            
+            due_date = due_date.strftime('%-m/%-d/%Y %l:%M%P')
           else
             due_date = due_date.strftime('%-m/%-d/%Y')
           end

--- a/spec/unit/voyager_helpers/liberator_spec.rb
+++ b/spec/unit/voyager_helpers/liberator_spec.rb
@@ -226,7 +226,7 @@ describe VoyagerHelpers::Liberator do
     it 'includes chron date with enumeration info when present' do
       allow(described_class).to receive(:get_items_for_holding).and_return(enum_with_chron)
       availability = described_class.get_full_mfhd_availability(placeholder_id).first
-      expect(availability[:enum]).to include("(#{chron_info})")
+      expect(availability[:enum_display]).to include("(#{chron_info})")
     end
     it 'includes copy number for non-reserve items if value is not 1' do
       allow(described_class).to receive(:get_items_for_holding).and_return(single_volume_2_copy)


### PR DESCRIPTION
puts the orangelight availability display enum/chron combo into a new property called `enum_display`, while keeping `enum` and `chron` properties separate.